### PR TITLE
remove need for sleep and second attempt when enabling

### DIFF
--- a/Sources/do-not-disturb/DoNotDisturb.swift
+++ b/Sources/do-not-disturb/DoNotDisturb.swift
@@ -13,15 +13,14 @@ public struct DoNotDisturb {
 	}
 
 	private static func enable() {
+        set("dndStart", value: nil)
+        set("dndEnd", value: nil)
+        commitChanges()
+
 		set("dndStart", value: 0 as CFPropertyList)
 		set("dndEnd", value: 1440 as CFPropertyList)
 		set("doNotDisturb", value: true as CFPropertyList)
 		commitChanges()
-
-		// For some reason `doNotDisturb` does not take the first time around
-		// TODO: Figure out why
-		sleep(for: 0.4)
-		set("doNotDisturb", value: true as CFPropertyList)
 	}
 
 	private static func disable() {


### PR DESCRIPTION
I noticed setting `dnsStart` and `dndEnd` to nil and committing, before setting them with actual values removes the need for the sleep and second attempt.